### PR TITLE
Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM starefossen/ruby-node
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev
+RUN mkdir /Circular
+WORKDIR /Circular
+ADD Gemfile /Circular/Gemfile
+ADD Gemfile.lock /Circular/Gemfile.lock
+RUN bundle install
+ADD . /Circular
+RUN cd client && npm install
+RUN npm install npm-run-all

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM starefossen/ruby-node
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev
-RUN mkdir /Circular
-WORKDIR /Circular
-ADD Gemfile /Circular/Gemfile
-ADD Gemfile.lock /Circular/Gemfile.lock
+RUN mkdir /circular
+WORKDIR /circular
+ADD Gemfile /circular/Gemfile
+ADD Gemfile.lock /circular/Gemfile.lock
 RUN bundle install
-ADD . /Circular
+ADD . /circular
 RUN cd client && npm install
 RUN npm install npm-run-all

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM starefossen/ruby-node
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev
+RUN apt-get update -qq \
+    && apt-get install -y build-essential libpq-dev
 RUN mkdir /circular
 WORKDIR /circular
 ADD Gemfile /circular/Gemfile
 ADD Gemfile.lock /circular/Gemfile.lock
 RUN bundle install
 ADD . /circular
-RUN cd client && npm install
-RUN npm install npm-run-all
+RUN cd /circular/client \
+    && npm install \
+    && npm install npm-run-all

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: cd client && npm start
-api: bundle exec rails s -p 3001
+api: bundle exec rails s -b 0.0.0.0 -p 3001

--- a/README.md
+++ b/README.md
@@ -124,3 +124,41 @@ One advantage to running your software in *__containers__* is that you can stand
 
 ###Why Docker?
 Code for Denver is using Docker in an effort to reduce time spent onboarding new members onto new projects. By using Docker, we can take advantage of a standardized development environment shared by everyone working on a project and spend less time installing new software and setting up projects on everyone's unique machines. Every project repository contains a Dockerfile specific to that project that will configure and run the project within Docker containers - all you need to do to get started with a project is install Docker and follow the instructions below!
+
+## Setting Up Docker
+#### 1. Install Docker
+You will need docker loaded locally on your machine to access your developement environment.
+
+[Dowload Docker for your OS] (https://store.docker.com/search?type=edition&offering=community)
+
+Verify Docker is up and running. You should see the docker program icon in your tray, menu bar or dock. From the link provided you should have the latest version.
+
+#### 2. Ensure you have the lastest GitHub pull
+If you havent already done so you can use the GitHub Desktop App.
+
+[Donwload GitHub Desktop](https://help.github.com/desktop/guides/getting-started/installing-github-desktop/)
+
+
+#### 3. Run configuration script to connect to the Circular Docker Container
+
+You can access the script directly from within your local repository by navigating here:
+
+```
+/Users/<your user acct>/GitHub/Circular (for example)
+```
+
+
+Check the script ran?
+
+#### 5. Opening you Docker container with Kitematic (GUI)
+When clicking on the docker icon or in the drop down there Kitematic is listed and will require installation.
+
+You should see an containers you have interacted with listed in Kitemaitc fort quick access.
+
+#### 6. Opeing you docker container from the command line
+
+Access your local linux instance. for MAC OS and current linux users this is straight forward.
+
+For legacy Windows systems refer to the Docker docs site for instructions.
+
+[Docker for Windows Old School] (https://docs.docker.com/toolbox/toolbox_install_windows/)

--- a/README.md
+++ b/README.md
@@ -110,3 +110,17 @@ In order to run the test suite, use the commands below. `rails db:test:prepare` 
 $ rails db:test:prepare
 $ rspec
 ```
+## Running with Docker
+
+![Docker Logo](https://www.docker.com/sites/default/files/mono_horizontal_large.png)
+
+###What is Docker?
+Docker is a software platform that allows you to develop and run your software in *__containers__*. 
+
+*__Containers__* are isolated environments in which you can install and run your software along with any libraries and denpendcies your software needs without the bloat that comes with running a full operating system like you normally would within a Virtual Machine. You can learn more about Docker *__containers__* [here](https://www.docker.com/what-container).
+
+One advantage to running your software in *__containers__* is that you can standardize your development environment and eliminate problems that may arise out of having a unique development environment or working with other developers that may also have unique development environments.
+
+
+###Why Docker?
+Code for Denver is using Docker in an effort to reduce time spent onboarding new members onto new projects. By using Docker, we can take advantage of a standardized development environment shared by everyone working on a project and spend less time installing new software and setting up projects on everyone's unique machines. Every project repository contains a Dockerfile specific to that project that will configure and run the project within Docker containers - all you need to do to get started with a project is install Docker and follow the instructions below!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,11 @@ services:
     command: rake start
     depends_on:
       - db
-    ports: 
+    links:
+      - db
+    ports:
       - "3000:3000"
       - "3001:3001"
     volumes:
       - .:/circular
+    tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  db:
+    expose:
+      - "5432"
+    image: postgres
+  web:
+    build: .
+    command: rake start
+    depends_on:
+      - db
+    ports: 
+      - "3000:3000"
+      - "3001:3001"
+    volumes:
+      - .:/Circular

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,4 +13,4 @@ services:
       - "3000:3000"
       - "3001:3001"
     volumes:
-      - .:/Circular
+      - .:/circular


### PR DESCRIPTION
This resolves the failure of `npm install` and `npm install npm-run-all` on the initial `docker-compose up`. The error was encountered after attempting to run `rake start` via the command field in `docker-compose.yml`.

When testing, make sure you shut down all other applications running on ports 3000 and 3001, then remove any previous container and image(s):
- `docker rm circular_web_1`
- `docker rm circular_db_1`
- `docker rmi circular_web`