### PR TITLE
Remove ability to add new campaign to existing address

### DIFF
--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router';
-import { OAuthSignInButton, SignOutButton } from "redux-auth/default-theme";
-import { ButtonGroup } from "react-bootstrap";
+import { OAuthSignInButton, SignOutButton } from 'redux-auth/default-theme';
+import { ButtonGroup } from 'react-bootstrap';
 
 const NavBar = () => (
   <nav className="navbar">
@@ -9,7 +9,9 @@ const NavBar = () => (
       <div className="row">
         <div className="col-md-9 navbar-header">
           <p>
-            <Link className="home-link" to="/">Recycling Request Tool</Link>
+            <Link className="home-link" to="/">
+              Recycling Request Tool
+            </Link>
           </p>
         </div>
 

--- a/client/src/containers/ChooseCampaign.js
+++ b/client/src/containers/ChooseCampaign.js
@@ -25,7 +25,9 @@ class ChooseCampaign extends Component {
     const selectedOption = this.state.selectedOption;
     console.log('You have selected:', selectedOption);
     const { selectedAddress } = this.props;
-    if (!selectedAddress || selectedAddress === 'none') {
+    if (selectedAddress === 'different') {
+      this.props.router.push('/');
+    } else if (!selectedAddress || selectedAddress === 'none') {
       this.props.router.push('/new-campaign/address');
     } else {
       this.props.fetchCampaignById(selectedAddress.id);
@@ -49,7 +51,14 @@ class ChooseCampaign extends Component {
   }
 
   render() {
-    const { error, nearbyCampaigns, loading, loaded, selectedAddress } = this.props;
+    const {
+      error,
+      nearbyCampaigns,
+      loading,
+      loaded,
+      selectedAddress,
+      searchedAddress
+    } = this.props;
 
     return (
       <div className="hero_wrapper">
@@ -77,18 +86,32 @@ class ChooseCampaign extends Component {
                       selectedAddress,
                       this.handleOptionChange
                     )}
-                    <li className="chooseCampaign-item" key="no-match">
-                      <input
-                        id="none"
-                        type="radio"
-                        value={'none'}
-                        checked={selectedAddress === 'none'}
-                        onChange={this.handleOptionChange}
-                      />
-                      <label htmlFor="none">
-                        {"None of these match my address. Let's start a new campaign."}
-                      </label>
-                    </li>
+                    {nearbyCampaigns[0].street_address === searchedAddress.formatted_address && (
+                      <li className="chooseCampaign-item" key="no-match">
+                        <input
+                          id="different"
+                          type="radio"
+                          value={'different'}
+                          checked={selectedAddress === 'different'}
+                          onChange={this.handleOptionChange}
+                        />
+                        <label htmlFor="different">{'Input a different address.'}</label>
+                      </li>
+                    )}
+                    {nearbyCampaigns[0].street_address !== searchedAddress.formatted_address && (
+                      <li className="chooseCampaign-item" key="no-match">
+                        <input
+                          id="none"
+                          type="radio"
+                          value={'none'}
+                          checked={selectedAddress === 'none'}
+                          onChange={this.handleOptionChange}
+                        />
+                        <label htmlFor="none">
+                          {"None of these match my address. Let's start a new campaign."}
+                        </label>
+                      </li>
+                    )}
                   </ul>
                 </form>
               )}

--- a/client/src/containers/ChooseCampaign.js
+++ b/client/src/containers/ChooseCampaign.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { selectAddress } from '../redux/actions/initialSearch';
 import fetchCampaignById from '../redux/actions/activeCampaign';
+import AutoSuggestInput from '../components/AutoSuggestInput';
 
 class ChooseCampaign extends Component {
   constructor(props) {
@@ -75,45 +76,63 @@ class ChooseCampaign extends Component {
             {loaded &&
               nearbyCampaigns &&
               Array.isArray(nearbyCampaigns) && (
-                <form className="">
-                  <h1 className="search_address_heading">{'We found these campaigns near you.'}</h1>
-                  <h2 className="search_address_sub_heading">
-                    {'Do any of these campaigns represent where you live?'}
-                  </h2>
-                  <ul className="chooseCampaign-list">
-                    {this.renderNearbyCampaigns(
-                      nearbyCampaigns,
-                      selectedAddress,
-                      this.handleOptionChange
-                    )}
-                    {nearbyCampaigns[0].street_address === searchedAddress.formatted_address && (
-                      <li className="chooseCampaign-item" key="no-match">
-                        <input
-                          id="different"
-                          type="radio"
-                          value={'different'}
-                          checked={selectedAddress === 'different'}
-                          onChange={this.handleOptionChange}
-                        />
-                        <label htmlFor="different">{'Input a different address.'}</label>
-                      </li>
-                    )}
-                    {nearbyCampaigns[0].street_address !== searchedAddress.formatted_address && (
-                      <li className="chooseCampaign-item" key="no-match">
-                        <input
-                          id="none"
-                          type="radio"
-                          value={'none'}
-                          checked={selectedAddress === 'none'}
-                          onChange={this.handleOptionChange}
-                        />
-                        <label htmlFor="none">
-                          {"None of these match my address. Let's start a new campaign."}
-                        </label>
-                      </li>
-                    )}
-                  </ul>
-                </form>
+                <div>
+                  {nearbyCampaigns[0].street_address === searchedAddress.formatted_address && (
+                    <form className="">
+                      <h1 className="search_address_heading">
+                        {'Your address already has a campaign!.'}
+                      </h1>
+                      <h2 className="search_address_sub_heading">{'Is this your address?'}</h2>
+                      <ul className="chooseCampaign-list">
+                        {this.renderNearbyCampaigns(
+                          nearbyCampaigns,
+                          selectedAddress,
+                          this.handleOptionChange
+                        )}
+                        <div className="btn-wrapper">
+                          <button className="btn" type="submit" onClick={this.handleFormSubmit}>
+                            {"YES - LET'S DO THIS!"}
+                          </button>
+                        </div>
+                        <AutoSuggestInput />
+                      </ul>
+                    </form>
+                  )}
+                  {nearbyCampaigns[0].street_address !== searchedAddress.formatted_address && (
+                    <form className="">
+                      <h1 className="search_address_heading">
+                        {'We found these campaigns near you.'}
+                      </h1>
+                      <h2 className="search_address_sub_heading">
+                        {'Do any of these campaigns represent where you live?'}
+                      </h2>
+                      <ul className="chooseCampaign-list">
+                        {this.renderNearbyCampaigns(
+                          nearbyCampaigns,
+                          selectedAddress,
+                          this.handleOptionChange
+                        )}
+                        <li className="chooseCampaign-item" key="no-match">
+                          <input
+                            id="none"
+                            type="radio"
+                            value={'none'}
+                            checked={selectedAddress === 'none'}
+                            onChange={this.handleOptionChange}
+                          />
+                          <label htmlFor="none">
+                            {"None of these match my address. Let's start a new campaign."}
+                          </label>
+                        </li>
+                      </ul>
+                      <div className="btn-wrapper">
+                        <button className="btn" type="submit" onClick={this.handleFormSubmit}>
+                          {"OK - LET'S DO THIS!"}
+                        </button>
+                      </div>
+                    </form>
+                  )}
+                </div>
               )}
             {!loading &&
               nearbyCampaigns &&
@@ -129,11 +148,13 @@ class ChooseCampaign extends Component {
                   <h2 className="search_address_sub_heading">
                     {'(We promise it will only take a minute)'}
                   </h2>
+                  <div className="btn-wrapper">
+                    <button className="btn" type="submit" onClick={this.handleFormSubmit}>
+                      {"OK - LET'S DO THIS!"}
+                    </button>
+                  </div>
                 </div>
               )}
-            <button className="btn" type="submit" onClick={this.handleFormSubmit}>
-              {"OK - LET'S DO THIS!"}
-            </button>
           </div>
         </div>
       </div>

--- a/client/src/redux/reducers/initialSearch.js
+++ b/client/src/redux/reducers/initialSearch.js
@@ -38,7 +38,8 @@ export default function (state = defaultState, action) {
     case VALIDATE_ADDRESS_FAILURE:
       return {
         error: {
-          userMessage: "Sorry, we couldn't locate that address. Try selecting one of the auto-suggested addresses for better accuracy.",
+          userMessage:
+            "Sorry, we couldn't locate that address. Try selecting one of the auto-suggested addresses for better accuracy.",
           searchError: error
         }
       };
@@ -60,15 +61,15 @@ export default function (state = defaultState, action) {
           dbResponse: error
         }
       };
-    case SELECT_ADDRESS:
-      {
-        const selectedAddress = state.nearbyCampaigns.find(c => c.street_address === action.value) || 'none';
-        return {
-          ...state,
-          selectedAddress,
-          error: null
-        };
-      }
+    case SELECT_ADDRESS: {
+      const selectedAddress =
+        state.nearbyCampaigns.find(c => c.street_address === action.value) || action.value;
+      return {
+        ...state,
+        selectedAddress,
+        error: null
+      };
+    }
     case 'STASH_ADDRESS':
       return {
         ...state,
@@ -114,7 +115,7 @@ export default function (state = defaultState, action) {
         ...state,
         searchedAddress: null,
         error
-      }
+      };
     default:
       return state;
   }

--- a/client/src/stylesheets/components/_AutoSuggestInput.scss
+++ b/client/src/stylesheets/components/_AutoSuggestInput.scss
@@ -1,161 +1,161 @@
 .autosuggest_input_form {
-	width: 100%;
-	height: 100%;
-	opacity: 1;
-	position: relative;
+  width: 100%;
+  height: 100%;
+  opacity: 1;
+  position: relative;
 }
 
 .error-box {
-	height: 30px;
-	width: 100%;
-	max-width: 530px;
-	margin: auto;
-	border-radius: 2px 2px 0 0;
-	transition-property: transform;
-	background-color: #BA4100;
-	color: white;
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	transition-duration: .2s;
-	transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
-	&.open {
-		transform: translate(0, 0%);
-	}
-	&.closed {
-		transform: translate(0, 100%);
-	}
+  height: 30px;
+  width: 100%;
+  max-width: 530px;
+  margin: auto;
+  margin-top: 0px;
+  border-radius: 2px 2px 0 0;
+  transition-property: transform;
+  background-color: #ba4100;
+  color: white;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition-duration: 0.2s;
+  transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
+  &.open {
+    transform: translate(0, 0%);
+  }
+  &.closed {
+    transform: translate(0, 100%);
+  }
 }
 
 .error-text {
-	font-family: 'Fira Sans Condensed';
+  font-family: 'Fira Sans Condensed';
 }
 
 .search_input,
 .search_input:focus,
 .search_input:active {
-	width: 100%;
-	margin: 16px;
-	margin-right: 0;
-	color: $secondary-color;
-	padding: 0;
-	background-color: #FAFAFA;
+  width: 100%;
+  margin: 16px;
+  margin-right: 0;
+  color: $secondary-color;
+  padding: 0;
+  background-color: #fafafa;
   display: inline-block;
   font-size: 16px;
-	border: none;
+  border: none;
   outline: none;
 }
 
-.input_form, 
+.input_form,
 .input_form:focus,
 .input_form:active {
-		position: relative;
-	height: 52px;
-	background-color: #FAFAFA;
-	box-shadow: 0 0 2px 0 rgba(0,0,0,0.12), 0 2px 2px 0 rgba(0,0,0,0.24);
+  position: relative;
+  height: 52px;
+  background-color: #fafafa;
+  box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.12), 0 2px 2px 0 rgba(0, 0, 0, 0.24);
   padding: 0;
   font-size: 16px;
-	border: none;
+  border: none;
   border-radius: 2px;
-	border-bottom: 1px solid transparent;
+  border-bottom: 1px solid transparent;
   outline: none;
-	display: flex;
-	flex-direction: row;
-	align-items: flex-start;
-	justify-content: flex-start;
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: flex-start;
   border-bottom: honeydew;
   border-left: honeydew;
   border-right: honeydew;
   border-radius: 2px;
-	max-width: 530px;
-	margin: auto;
-	z-index: 1000;
+  max-width: 530px;
+  margin: auto;
+  z-index: 1000;
 }
 
 .autocomplete_container {
-	width: calc(100% + 52px);
+  width: calc(100% + 52px);
   border-bottom: honeydew;
   border-left: honeydew;
   border-right: honeydew;
   border: 1px solid #e6e6e6;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   border-radius: 0 0 2px 2px;
 }
 
 .form_group {
-	width: calc(100% - 104px);
-	position: 'relative';
-	padding-bottom: 0px;
+  width: calc(100% - 104px);
+  position: 'relative';
+  padding-bottom: 0px;
 }
 
 .input_suggestion_item {
   padding: 10px;
-	text-align: left;
-	cursor: pointer;
+  text-align: left;
+  cursor: pointer;
 }
 
 .input_suggestion_item_active {
-	@extend .input_suggestion_item;
-	background-color: #E1F5EF;
+  @extend .input_suggestion_item;
+  background-color: #e1f5ef;
 }
 
 .suggestion_text_bold {
-	font-weight: 600;
-	color: $secondary-color;
+  font-weight: 600;
+  color: $secondary-color;
 }
 
 .search_button {
-	border: none;
-	position: absolute;
-	border-radius: 0 2px 2px 0;
-	right: 0;
-	background-color: rgba($secondary-color, 0.85);
-	height: 52px;
-	width: 52px;
-	display: inline-block;
-	color: $mainwhite;
+  border: none;
+  position: absolute;
+  border-radius: 0 2px 2px 0;
+  right: 0;
+  background-color: rgba($secondary-color, 0.85);
+  height: 52px;
+  width: 52px;
+  display: inline-block;
+  color: $mainwhite;
 
-	&:hover:not(:disabled), 
-	&:focus {
-		cursor: pointer;
-		background-color: $secondary-color;
-		z-index: 100;
-	}
-	
-	&:disabled {
-		opacity: 0.75;
-	}
-	
+  &:hover:not(:disabled),
+  &:focus {
+    cursor: pointer;
+    background-color: $secondary-color;
+    z-index: 100;
+  }
+
+  &:disabled {
+    opacity: 0.75;
+  }
 }
 
 .fa-map-marker {
-	color: $secondary-color;
+  color: $secondary-color;
 }
 
 .clear_button {
-	border: none;
-	padding: 0;
-	color: $secondary-color;
-	position: absolute;
-	align-self: center;
-	right: 52px;
-	margin: 0 2px 2px 0;
-	background-color: #FAFAFA;
-	height: 41px;
-	width: 41px;
-	display: inline-block;
+  border: none;
+  padding: 0;
+  color: $secondary-color;
+  position: absolute;
+  align-self: center;
+  right: 52px;
+  margin: 0 2px 2px 0;
+  background-color: #fafafa;
+  height: 41px;
+  width: 41px;
+  display: inline-block;
 
-		&:hover {
-		cursor: pointer;
-	}
+  &:hover {
+    cursor: pointer;
+  }
 
-	&:focus {
-		z-index: 100;
-	}
+  &:focus {
+    z-index: 100;
+  }
 }
 
 .suggestion_text_muted {
-	font-weight: lighter;
-	font-size: 0.75em;
-	color: rgba($secondary-color, 0.85);
+  font-weight: lighter;
+  font-size: 0.75em;
+  color: rgba($secondary-color, 0.85);
 }

--- a/client/src/stylesheets/components/_ChooseCampaign.scss
+++ b/client/src/stylesheets/components/_ChooseCampaign.scss
@@ -1,57 +1,57 @@
 @import '../base/colors';
 
 .chooseCampaign-list {
-		margin-bottom: 2rem;
+  margin-bottom: 2rem;
 }
 
 .chooseCampaign-item {
-	margin: .5rem 0;
+  margin: 0.5rem 0;
 
-	&:first-of-type {
-		margin-top: 0;
-	}
+  &:first-of-type {
+    margin-top: 0;
+  }
 }
 
 .chooseCampaign-item label {
-	background-color: #fff;
-	display: block;
-	padding: 1.5rem 3rem;
-	transition: transform .2s, box-shadow .4s;
-	transition-timing-function: cubic-bezier(.25, .25, .1, 2);
-	box-shadow: 0px 0px 2px 0px rgba(20, 20, 20, .2);
-	border-radius: 2px;
+  background-color: #fff;
+  display: block;
+  padding: 1.5rem 3rem;
+  transition: transform 0.2s, box-shadow 0.4s;
+  transition-timing-function: cubic-bezier(0.25, 0.25, 0.1, 2);
+  box-shadow: 0px 0px 2px 0px rgba(20, 20, 20, 0.2);
+  border-radius: 2px;
 
-	&:hover {
-		box-shadow: 0px 0px 4px 2px rgba(20, 20, 20, .2);
-	}
-
+  &:hover {
+    box-shadow: 0px 0px 4px 2px rgba(20, 20, 20, 0.2);
+  }
 }
 
-.chooseCampaign-item input:checked + label  {
-	transform: scale(1.03);
-	box-shadow: 0px 2px 20px 4px rgba(20, 20, 20, .3);
+.chooseCampaign-item input:checked + label {
+  transform: scale(1.03);
+  box-shadow: 0px 2px 20px 4px rgba(20, 20, 20, 0.3);
 }
 
 .chooseCampaign-item input {
-	display: none;
-
+  display: none;
 }
 
 .chooseCampaign-item input + label:before {
-	font-family: 'FontAwesome';
-	content: '\f00c';
-	color: $maingreen;
-	position: absolute;
-	display: inline-block;
-	left: 1.5rem;
-	transform: scale(0);
-	transition: transform .1s;
+  font-family: 'FontAwesome';
+  content: '\f00c';
+  color: $maingreen;
+  position: absolute;
+  display: inline-block;
+  left: 1.5rem;
+  transform: scale(0);
+  transition: transform 0.1s;
 
-	transition-timing-function: cubic-bezier(.25, .25, .1, 1);
-	
+  transition-timing-function: cubic-bezier(0.25, 0.25, 0.1, 1);
 }
 
 .chooseCampaign-item input:checked + label:before {
-	transform: scale(1.4);
-
+  transform: scale(1.4);
+}
+.btn-wrapper {
+  margin-top: 15px;
+  text-align: center;
 }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,7 +3,7 @@ require 'database_cleaner'
 DatabaseCleaner.clean_with(:truncation)
 
 Campaign.create!([
-  { street_address: '710 E 26th Ave, Denver, CO 80205', lat: 39.7544539, lng: -104.97782, name: 'Nuggets', vote_count: 4 },
+  { street_address: '710 E 26th Ave, Denver, CO 80205, USA', lat: 39.7544539, lng: -104.97782, name: 'Nuggets', vote_count: 4 },
   { street_address: '1435 Jersey St, Denver, CO 80220, USA', lat: 39.739163, lng: -104.920209, name: 'Rockies', vote_count: 3 },
   { street_address: 'Barnum West, Denver, CO, USA', lat: 39.721756, lng: -105.044840, name: 'Avalanche', vote_count: 7 },
   { street_address: 'Platt Park, Denver, CO 80210, USA', lat: 39.696614, lng: -104.982272, name: 'Cherry Creek', vote_count: 6 },


### PR DESCRIPTION
On the choose campaign page, if the inputed address matches an address in the db, add an option for 'Input different address' and remove the option to start a new campaign

Also fixes first address in seed file to match exact address given by google