### PR TITLE
fixed issue with loading campaign page immediately after campaign creation

### DIFF
--- a/client/src/components/CampaignProgressBar.js
+++ b/client/src/components/CampaignProgressBar.js
@@ -32,13 +32,15 @@ class CampaignProgessBar extends React.Component {
   };
 
   render() {
-    const phaseDates = this.getPhaseCompletionDates(
-      this.props.createdAt,
-      this.props.phases.length,
-      this.props.duration
-    );
+    let { createdAt, phases, duration } = this.props;
+    const timestamp = Date.parse(createdAt);
+    if (isNaN(timestamp)) {
+      createdAt = new Date(Date.now()).toString();
+    }
+
+    const phaseDates = this.getPhaseCompletionDates(createdAt, phases.length, duration);
     const progressSteps = phaseDates.map((phaseDate, index) =>
-      this.renderProgressPhase(phaseDate, this.props.phases[index])
+      this.renderProgressPhase(phaseDate, phases[index])
     );
 
     return <div>{progressSteps}</div>;

--- a/client/src/components/CampaignProgressBar.js
+++ b/client/src/components/CampaignProgressBar.js
@@ -32,7 +32,8 @@ class CampaignProgessBar extends React.Component {
   };
 
   render() {
-    let { createdAt, phases, duration } = this.props;
+    let { createdAt } = this.props;
+    const { phases, duration } = this.props;
     const timestamp = Date.parse(createdAt);
     if (isNaN(timestamp)) {
       createdAt = new Date(Date.now()).toString();

--- a/client/src/components/CampaignStatus.js
+++ b/client/src/components/CampaignStatus.js
@@ -15,7 +15,8 @@ class CampaignStatus extends React.Component {
   };
 
   render() {
-    let { createdAt, duration } = this.props;
+    let { createdAt } = this.props;
+    const { duration } = this.props;
     const timestamp = Date.parse(createdAt);
     if (isNaN(timestamp)) {
       createdAt = new Date(Date.now()).toString();

--- a/client/src/components/CampaignStatus.js
+++ b/client/src/components/CampaignStatus.js
@@ -15,10 +15,16 @@ class CampaignStatus extends React.Component {
   };
 
   render() {
+    let { createdAt, duration } = this.props;
+    const timestamp = Date.parse(createdAt);
+    if (isNaN(timestamp)) {
+      createdAt = new Date(Date.now()).toString();
+    }
+
     return (
       <Col className="status " md={12} xs={12}>
         <div className="text-center status-date">
-          <h3>{this.calculateDaysLeft(this.props.createdAt, this.props.duration)}</h3>
+          <h3>{this.calculateDaysLeft(createdAt, duration)}</h3>
           <p>Days Left</p>
           <i className="fa fa-calendar" aria-hidden="true" />
         </div>

--- a/client/src/components/SignCampaign.js
+++ b/client/src/components/SignCampaign.js
@@ -119,7 +119,11 @@ class SignCampaign extends Component {
             <ControlLabel id="control-label">
               <h4>I'm signing because...</h4>
             </ControlLabel>
-            <FormControl componentClass="textarea" placeholder="Optional" />
+            <FormControl
+              className="form-resize-vertical"
+              componentClass="textarea"
+              placeholder="Optional"
+            />
           </FormGroup>
         </Col>
       </Row>

--- a/client/src/containers/CampaignPage.js
+++ b/client/src/containers/CampaignPage.js
@@ -177,27 +177,28 @@ class CampaignPage extends Component {
                 </div>
               </Col>
             </Row>
-            {campaign && (
-              <Row className="show-grid top">
-                <Col className="status-bar" md={8} xs={12}>
-                  <Row>
-                    <CampaignProgressBar
-                      createdAt={campaign.createdAt}
-                      phases={[
-                        'Campaign Created',
-                        'Print Flyers',
-                        'Final Signatures',
-                        'Request Recycling'
-                      ]}
-                      duration={CAMPAIGN_DURATION}
-                    />
-                  </Row>
-                </Col>
-                <Col className="status-bar" md={4} xs={12}>
-                  <CampaignStatus createdAt={campaign.createdAt} duration={CAMPAIGN_DURATION} />
-                </Col>
-              </Row>
-            )}
+            {campaign &&
+              campaign.createdAt && (
+                <Row className="show-grid top">
+                  <Col className="status-bar" md={8} xs={12}>
+                    <Row>
+                      <CampaignProgressBar
+                        createdAt={campaign.createdAt}
+                        phases={[
+                          'Campaign Created',
+                          'Print Flyers',
+                          'Final Signatures',
+                          'Request Recycling'
+                        ]}
+                        duration={CAMPAIGN_DURATION}
+                      />
+                    </Row>
+                  </Col>
+                  <Col className="status-bar" md={4} xs={12}>
+                    <CampaignStatus createdAt={campaign.createdAt} duration={CAMPAIGN_DURATION} />
+                  </Col>
+                </Row>
+              )}
             <Row className="show-grid top">
               <Col md={12} xs={12}>
                 <Col md={3} xs={10} className="tools">
@@ -256,7 +257,11 @@ CampaignPage.propTypes = {
 };
 
 export default connect(
-  ({ activeCampaign, signature, initialSearch }) => ({ activeCampaign, signature, initialSearch }),
+  ({ activeCampaign, signature, initialSearch }) => ({
+    activeCampaign,
+    signature,
+    initialSearch
+  }),
   {
     fetchCampaignById,
     fetchSignatures,

--- a/client/src/stylesheets/components/_SignCampaign.scss
+++ b/client/src/stylesheets/components/_SignCampaign.scss
@@ -62,6 +62,12 @@ h5 {
   }
 }
 
+.form-resize-vertical {
+  resize: vertical;
+  min-height: 75px;
+  max-height: 150px;
+}
+
 // .error-message {
 //   color: red;
 // }


### PR DESCRIPTION
immediately after a campaign is created, the campaignPage is loaded before the createdAt property on the campaign object is set (undefined).  this was causing the progress bar to crash and the CampaignPage to not load

solution was to only render the CampaignProgressBar and CampaignStatus if campaign object has a createdAt property.
Also CampaignProgressBar and CampaignStatus default bar or undefined date strings to Date.now() to prevent a catastrophic app crash