### PR TITLE
316 navbar clickability

### DIFF
--- a/client/src/components/CollapsePanel.js
+++ b/client/src/components/CollapsePanel.js
@@ -34,7 +34,7 @@ class CollapsePanel extends Component {
         >
           <Panel.Toggle className="collapse-panel-toggle">
             <Panel.Heading className={this.props.headingStyle}>
-              <Panel.Title className="collapse-panel-title" toggle>
+              <Panel.Title className="collapse-panel-title">
                 {titleText}
                 <i className="fa fa-chevron-down float-right" />
               </Panel.Title>

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -7,8 +7,8 @@ import { logSignerOut, fetchUserSignatures } from '../redux/actions/signature';
 
 function MyCampaignNavItem(props) {
   return (
-    <NavItem eventKey={4}>
-      <Link to={`/campaign/${props.campaignId}`}>My Campaign</Link>
+    <NavItem eventKey={4} href={`/campaign/${props.campaignId}`}>
+      My Campaign
     </NavItem>
   );
 }
@@ -66,19 +66,19 @@ class NavBar extends React.Component {
         </Navbar.Header>
         <Navbar.Collapse>
           <Nav pullRight>
-            <NavItem eventKey={1}>
-              <Link to="/denver-learn-more">Why</Link>
+            <NavItem eventKey={1} href="/denver-learn-more">
+              Why
             </NavItem>
             <NavDropdown id="tools-dropdown" eventKey={2} title="Tools">
-              <MenuItem eventKey={2.1}>
-                <Link to="/manager-resources">Property Manager Resources</Link>
+              <MenuItem eventKey={2.1} href="/manager-resources">
+                Property Manager Resources
               </MenuItem>
-              <MenuItem eventKey={2.2}>
-                <Link to="/tips-for-requesting">Tips for Requesting</Link>
+              <MenuItem eventKey={2.2} href="/tips-for-requesting">
+                Tips for Requesting
               </MenuItem>
             </NavDropdown>
-            <NavItem eventKey={3}>
-              <Link to="/who-are-we">Who Are We</Link>
+            <NavItem eventKey={3} href="/who-are-we">
+              Who Are We
             </NavItem>
             {/*  RENDERS MyCampaignNavItem BASED ON AUTH STATUS */}
             {userHasSignedCampaign && (

--- a/client/src/stylesheets/components/_collapsePanel.scss
+++ b/client/src/stylesheets/components/_collapsePanel.scss
@@ -10,6 +10,7 @@
 
   .collapse-panel-title {
     font-size: 20px;
+    color: $mainwhite;
     a {
       color: $mainwhite;
       text-decoration: none;


### PR DESCRIPTION
connect #316 
- expanded clickable area of navbar links to entire block.  removed <Link> Tags in favor of the href attribute on MenuItem/NavItem tags.  When we update to react-router v4 we use <LinkContainer> tag from 'react-router-bootstrap' package (https://github.com/react-bootstrap/react-router-bootstrap).


CLEANUP: 
 - resolved collapse panel console warning about nested <a> tags