### PR TITLE
Update defaultZoom and defaultCenter in MapCard

### DIFF
--- a/client/src/components/MapCard.js
+++ b/client/src/components/MapCard.js
@@ -9,8 +9,11 @@ const MapWithAMarker = withRouter(
     withGoogleMap(props => (
       <GoogleMap
         ref={props.onMapLoad}
-        defaultZoom={10}
-        defaultCenter={{ lat: 39.7392, lng: -104.9903 }}
+        defaultZoom={15}
+        defaultCenter={{
+            lat: props.activeCampaign.latLng._lat || 39.7392,
+            lng: props.activeCampaign.latLng._long || -104.9903
+          }}
         onClick={props.onMapClick}
       >
         <Marker


### PR DESCRIPTION
This pull request is to address issue #465. The goal is to ensure that any map we show on the site will have enough of a zoom to allow users to see the area they searched and that the map shown is centered on the location that the user searched. I left the default values to center on Denver in place so that we will always have a reasonable fallback.